### PR TITLE
Capture intermediate output

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mocha": "^2.3.3"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "pegjs": "^0.9.0"
   }
 }

--- a/src/capture.js
+++ b/src/capture.js
@@ -3,11 +3,12 @@
 var Capture = module.exports = function (robot) {
   this.robot = robot;
   this.captured = [];
-  this.completeCallback = function () {};
+  this.completeCallback = null;
 };
 
 Capture.prototype.onComplete = function (callback) {
   this.completeCallback = callback;
+  this._checkCompletion();
 };
 
 Capture.prototype.patchedRobot = function (id) {
@@ -35,19 +36,24 @@ Capture.prototype._capture = function (id, msg) {
 };
 
 Capture.prototype._isComplete = function () {
+  if (this.completeCallback === null) {
+    return false;
+  }
+
   return ! this.captured.some(function (each) {
     return each.length === 0;
-  }.bind(this));
+  });
 }
 
 Capture.prototype._checkCompletion = function () {
   while (this._isComplete()) {
     var result = [];
 
+    // TODO: this should actually handle permutations, somehow
     this.captured.forEach(function (each, i) {
       result[i] = each.shift();
     }.bind(this));
 
-    this.completeCallback(result);
+    this.completeCallback(null, result);
   }
 };

--- a/src/capture.js
+++ b/src/capture.js
@@ -1,0 +1,48 @@
+"use strict";
+
+var Capture = module.exports = function (robot) {
+  this.robot = robot;
+  this.captured = {};
+  this.idsRemaining = [];
+  this.completeCallback = function () {};
+};
+
+Capture.prototype.onComplete = function (callback) {
+  this.completeCallback = callback;
+};
+
+Capture.prototype.patchedRobot = function (id) {
+  var self = this;
+  var patchedAdapter = Object.create(this.robot.adapter);
+
+  this.idsRemaining.push(id);
+
+  patchedAdapter.send = function () {
+    var strings = Array.prototype.slice.call(arguments, 1);
+    console.log("got: " + strings.join(", "));
+    strings.forEach(function (arg) {
+      self._capture(id, arg);
+    });
+  };
+
+  var patchedRobot = Object.create(this.robot);
+  patchedRobot.adapter = patchedAdapter;
+
+  return patchedRobot;
+};
+
+Capture.prototype._capture = function (id, msg) {
+  this.captured[id] = msg;
+
+  var ind = this.idsRemaining.indexOf(id);
+  if (ind === -1) {
+
+  }
+
+};
+
+Capture.prototype._checkCompletion = function () {
+  if (this.idsRemaining.length === 0) {
+    this.completeCallback(this.captured);
+  }
+};

--- a/src/capture.js
+++ b/src/capture.js
@@ -2,7 +2,7 @@
 
 var Capture = module.exports = function (robot) {
   this.robot = robot;
-  this.captured = {};
+  this.captured = [];
   this.completeCallback = function () {};
 };
 
@@ -35,17 +35,17 @@ Capture.prototype._capture = function (id, msg) {
 };
 
 Capture.prototype._isComplete = function () {
-  return ! Object.keys(this.captured).some(function (id) {
-    return this.captured[id].length === 0;
+  return ! this.captured.some(function (each) {
+    return each.length === 0;
   }.bind(this));
 }
 
 Capture.prototype._checkCompletion = function () {
   while (this._isComplete()) {
-    var result = {};
+    var result = [];
 
-    Object.keys(this.captured).forEach(function (id) {
-      result[id] = this.captured[id].shift();
+    this.captured.forEach(function (each, i) {
+      result[i] = each.shift();
     }.bind(this));
 
     this.completeCallback(result);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,16 @@
+"use strict";
+
+var shellParser = require('./shell-parser');
+
 module.exports = function (robot) {
-  //
+  robot.receiveMiddleware(function (context, next, done) {
+    var message = context.response.message;
+
+    if (message.constructor.name === 'TextMessage') {
+      var expr = shellParser.parse(message.text);
+      console.log(expr.dump());
+    } else {
+      next(done);
+    }
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
 "use strict";
 
 var shellParser = require('./shell-parser');
+var messenger = require('./messenger');
 
 module.exports = function (robot) {
   robot.receiveMiddleware(function (context, next, done) {
     var message = context.response.message;
 
-    if (message.constructor.name === 'TextMessage') {
-      var expr = shellParser.parse(message.text);
+    if (messenger.isTextMessage(message)) {
+      var expr = shellParser.parse(msg.text);
       console.log(expr.dump());
     } else {
       next(done);

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var Messenger = module.exports = function (message) {
+  this.message = message;
+};
+
+Messenger.isTextMessage = function (message) {
+  return message.constructor.name === 'TextMessage';
+};
+
+Messenger.prototype.create = function (text) {
+  var m = Object.create(this.message);
+  m.text = text;
+  m.done = false;
+  return m;
+};
+
+Messenger.prototype.makeEnvelope = function () {
+  return { room: this.message.room, user: this.message.user, message: this.message };
+}

--- a/test/ast-test.js
+++ b/test/ast-test.js
@@ -1,0 +1,66 @@
+"use babel";
+
+var expect = require('chai').expect;
+
+var ast = require('../src/ast');
+var Pipe = ast.Pipe;
+var Command = ast.Command;
+var Part = ast.Part;
+
+var Messenger = require('../src/messenger');
+
+function MockRobot () {
+  var self = this;
+
+  this.sent = [];
+  this.adapter = {
+    send: function (envelope, string) {
+      self.sent.push(string);
+    }
+  };
+};
+
+MockRobot.prototype.receive = function (message) {
+  this.adapter.send("the-envelope", "received {" + message.text + "}");
+};
+
+function makeMessenger() {
+  return new Messenger({
+    room: "a-room",
+    user: "a-user",
+    text: "original"
+  });
+};
+
+describe("Part", function () {
+
+  it("sends itself as-is", function () {
+    var r = new MockRobot();
+    var m = makeMessenger();
+
+    var p = new Part("text");
+
+    p.evaluate(r, m);
+    expect(r.sent).to.deep.equal(["text"]);
+  });
+
+});
+
+describe("Command", function () {
+
+  it("evaluates its parts, collects them, then sends to its robot", function () {
+    var robot = new MockRobot();
+    var messenger = makeMessenger();
+
+    var c = new Command([
+      new Part("one "),
+      new Part("two "),
+      new Part("three")
+    ]);
+
+    c.evaluate(robot, messenger);
+
+    expect(robot.sent).to.deep.equal(["received {one two three}"]);
+  });
+
+});

--- a/test/ast-test.js
+++ b/test/ast-test.js
@@ -64,3 +64,22 @@ describe("Command", function () {
   });
 
 });
+
+describe("Pipe", function () {
+
+  it("evaluates its commands from left to right, appending output to the next's input", function () {
+    var robot = new MockRobot();
+    var messenger = makeMessenger();
+
+    var p = new Pipe([
+      new Command([new Part("a0 "), new Part("a1")]),
+      new Command([new Part("b0 "), new Part("b1 ")]),
+      new Command([new Part("c0 "), new Part("c1 ")])
+    ]);
+
+    p.evaluate(robot, messenger);
+
+    expect(robot.sent).to.deep.equal(["received {c0 c1 received {b0 b1 received {a0 a1}}}"]);
+  });
+
+});

--- a/test/capture-test.js
+++ b/test/capture-test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+var expect = require('chai').expect;
+var Capture = require('../src/capture');
+
+describe("capture", function () {
+
+  var robot = {
+    adapter: {
+      send: function () { return "original"; }
+    }
+  };
+
+  var capture;
+
+  beforeEach(function () {
+    capture = new Capture(robot);
+  });
+
+  it("patches #send in the robot's adapter", function () {
+    var patched = capture.patchedRobot('the-id');
+
+    var result = patched.adapter.send({}, "something");
+    expect(capture.captured['the-id']).to.equal("something");
+  });
+
+  it("invokes its completion callback once all results are in", function () {
+    var patched0 = capture.patchedRobot('id0');
+    var patched1 = capture.patchedRobot('id1');
+
+    var parts = null;
+    capture.onComplete(function (p) {
+      parts = p;
+    });
+
+    expect(parts).to.be.null;
+
+    patched0.send("first part came in");
+    expect(parts).to.be.null;
+
+    patched1.send("second part came in");
+    expect(parts).to.equal({
+      id0: "first part came in",
+      id1: "second part came in"
+    });
+  });
+
+});

--- a/test/capture-test.js
+++ b/test/capture-test.js
@@ -32,7 +32,7 @@ describe("capture", function () {
     var patched1 = capture.patchedRobot(1);
 
     var parts = null;
-    capture.onComplete(function (p) {
+    capture.onComplete(function (err, p) {
       parts = p;
     });
 
@@ -46,6 +46,18 @@ describe("capture", function () {
       "first part came in",
       "second part came in"
     ]);
+  });
+
+  it("invokes the completion callback if results are already there", function () {
+    capture.patchedRobot(0).adapter.send({}, "one");
+    capture.patchedRobot(1).adapter.send({}, "two");
+
+    var parts = null;
+    capture.onComplete(function (err, p) {
+      parts = p;
+    });
+
+    expect(parts).to.deep.equal(["one", "two"]);
   });
 
 });

--- a/test/capture-test.js
+++ b/test/capture-test.js
@@ -18,10 +18,13 @@ describe("capture", function () {
   });
 
   it("patches #send in the robot's adapter", function () {
+    // Prevent the capture from being "complete"
+    capture.patchedRobot('other-id');
+
     var patched = capture.patchedRobot('the-id');
 
     var result = patched.adapter.send({}, "something");
-    expect(capture.captured['the-id']).to.equal("something");
+    expect(capture.captured['the-id']).to.deep.equal(["something"]);
   });
 
   it("invokes its completion callback once all results are in", function () {
@@ -35,11 +38,11 @@ describe("capture", function () {
 
     expect(parts).to.be.null;
 
-    patched0.send("first part came in");
+    patched0.adapter.send({}, "first part came in");
     expect(parts).to.be.null;
 
-    patched1.send("second part came in");
-    expect(parts).to.equal({
+    patched1.adapter.send({}, "second part came in");
+    expect(parts).to.deep.equal({
       id0: "first part came in",
       id1: "second part came in"
     });

--- a/test/capture-test.js
+++ b/test/capture-test.js
@@ -19,17 +19,17 @@ describe("capture", function () {
 
   it("patches #send in the robot's adapter", function () {
     // Prevent the capture from being "complete"
-    capture.patchedRobot('other-id');
+    capture.patchedRobot(1);
 
-    var patched = capture.patchedRobot('the-id');
+    var patched = capture.patchedRobot(0);
 
     var result = patched.adapter.send({}, "something");
-    expect(capture.captured['the-id']).to.deep.equal(["something"]);
+    expect(capture.captured[0]).to.deep.equal(["something"]);
   });
 
   it("invokes its completion callback once all results are in", function () {
-    var patched0 = capture.patchedRobot('id0');
-    var patched1 = capture.patchedRobot('id1');
+    var patched0 = capture.patchedRobot(0);
+    var patched1 = capture.patchedRobot(1);
 
     var parts = null;
     capture.onComplete(function (p) {
@@ -42,10 +42,10 @@ describe("capture", function () {
     expect(parts).to.be.null;
 
     patched1.adapter.send({}, "second part came in");
-    expect(parts).to.deep.equal({
-      id0: "first part came in",
-      id1: "second part came in"
-    });
+    expect(parts).to.deep.equal([
+      "first part came in",
+      "second part came in"
+    ]);
   });
 
 });

--- a/test/shell-parser-test.js
+++ b/test/shell-parser-test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var expect = require('chai').expect;
 
 var shellParser = require('../src/shell-parser');


### PR DESCRIPTION
Capture intermediate output from subcommands, assemble them into something the bot can understand, and re-route each through the normal listener stack with a patched `robot`.