### PR TITLE
Add a space before a pipe payload.

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -35,7 +35,7 @@ Pipe.prototype.evaluate = function (robot, messenger) {
     var command = self.commands[i];
 
     if (suffix !== "") {
-      command = command.suffixedWith(new Part(suffix));
+      command = command.suffixedWith(new Part(" " + suffix));
     }
 
     var patched = capture.patchedRobot(0);
@@ -56,7 +56,7 @@ Pipe.prototype.evaluate = function (robot, messenger) {
     var command = self.commands[finalCommandIndex];
 
     if (suffix !== "") {
-      command = command.suffixedWith(new Part(suffix));
+      command = command.suffixedWith(new Part(" " + suffix));
     }
 
     command.evaluate(robot, messenger);

--- a/test/ast-test.js
+++ b/test/ast-test.js
@@ -75,8 +75,8 @@ describe("Pipe", function () {
 
     var p = new Pipe([
       new Command([new Part("a0 "), new Part("a1")]),
-      new Command([new Part("b0 "), new Part("b1 ")]),
-      new Command([new Part("c0 "), new Part("c1 ")])
+      new Command([new Part("b0 "), new Part("b1")]),
+      new Command([new Part("c0 "), new Part("c1")])
     ]);
 
     p.evaluate(robot, messenger);


### PR DESCRIPTION
Piping commands together jams the output of the feeding command directly at the end of the next one:

```
pushbot> pushbot echo before | pushbot echo after
afterbefore 
```

This makes it awkward to write commands that use pipe input, because it's usually impossible to tell where the last user-supplied "argument" ends and the piped input begins. This adds an additional space between them:

```
pushbot> pushbot echo after | pushbot echo before
before after
```

A little less exact, but a lot more convenient.