### PR TITLE
Don't die on parse failures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,11 @@ module.exports = function (robot) {
           context.response.send(results.join(""));
         });
       } catch (e) {
-        next(done);
+        if (e.name === 'SyntaxError') {
+          next(done);
+        } else {
+          throw e;
+        }
       }
     } else {
       next(done);

--- a/src/index.js
+++ b/src/index.js
@@ -11,21 +11,25 @@ module.exports = function (robot) {
     var message = context.response.message;
 
     if (Messenger.isTextMessage(message) && ! context.response.robot.__hubot_pipe_patched) {
-      var expr = shellParser.parse(message.text);
-      var messenger = new Messenger(message);
-      var capture = new Capture(context.response.robot);
-      var patched = capture.patchedRobot(0);
+      try {
+        var expr = shellParser.parse(message.text);
+        var messenger = new Messenger(message);
+        var capture = new Capture(context.response.robot);
+        var patched = capture.patchedRobot(0);
 
-      expr.evaluate(patched, messenger);
+        expr.evaluate(patched, messenger);
 
-      capture.onComplete(function (err, results) {
-        if (err) {
-          console.error(err);
-          return;
-        };
+        capture.onComplete(function (err, results) {
+          if (err) {
+            console.error(err);
+            return;
+          };
 
-        context.response.send(results.join(""));
-      });
+          context.response.send(results.join(""));
+        });
+      } catch (e) {
+        next(done);
+      }
     } else {
       next(done);
     }

--- a/test/shell-parser-test.js
+++ b/test/shell-parser-test.js
@@ -141,14 +141,4 @@ describe("shellParser", function () {
 
   });
 
-  describe("with parse errors", function () {
-
-    it("doesn't crash", function () {
-      var input = "hubot echo $( unbalanced";
-      var expected = "(Pipe (Command (Part [hubot echo $( unbalanced])))";
-
-      parsesAs(input, expected);
-    });
-  });
-
 });

--- a/test/shell-parser-test.js
+++ b/test/shell-parser-test.js
@@ -141,4 +141,14 @@ describe("shellParser", function () {
 
   });
 
+  describe("with parse errors", function () {
+
+    it("doesn't crash", function () {
+      var input = "hubot echo $( unbalanced";
+      var expected = "(Pipe (Command (Part [hubot echo $( unbalanced])))";
+
+      parsesAs(input, expected);
+    });
+  });
+
 });


### PR DESCRIPTION
This catches the uncaught exception that's raised if someone says a line including unbalanced parenthesis, for example.