### PR TITLE
Handle Slack attachments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,25 @@ module.exports = function (robot) {
             return;
           };
 
-          context.response.send(results.join(""));
+          var accumulated = [];
+          for (var i = 0; i < results.length; i++) {
+            var result = results[i];
+
+            if (typeof result === 'string') {
+              accumulated.push(result);
+            } else {
+              if (accumulated.length > 0) {
+                context.response.send(accumulated.join(""));
+                accumulated = [];
+              }
+
+              context.response.send(result);
+            }
+          }
+
+          if (accumulated.length > 0) {
+            context.response.send(accumulated.join(""));
+          }
         });
       } catch (e) {
         if (e.name === 'SyntaxError') {


### PR DESCRIPTION
Slack attachments are messages with bodies that are objects rather than
text. Pass these through without performing a `.join("")`, which
converts them into the unhelpful `[Object object]`.